### PR TITLE
Only invoke OnReconnected() if Open() was successful

### DIFF
--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -120,8 +120,10 @@ namespace TwitchLib.Communication.Clients
         public void Reconnect()
         {
             Close();
-            Open();
-            OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
+            if(Open())
+            {
+                OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
+            }
         }
 
         public bool Send(string message)

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -106,8 +106,10 @@ namespace TwitchLib.Communication.Clients
         public void Reconnect()
         {
             Close();
-            Open();
-            OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
+            if(Open())
+            {
+                OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
+            }
         }
         
         public bool Send(string message)


### PR DESCRIPTION
OnReconnected() is currently being invoked regardless of `Open()` result. We should only invoke it if `Open()` succeeds.