### PR TITLE
Fix reconnect not working issue

### DIFF
--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.WebSockets;
@@ -119,11 +120,15 @@ namespace TwitchLib.Communication.Clients
 
         public void Reconnect()
         {
-            Close();
-            if(Open())
+            Task.Run(() =>
             {
-                OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
-            }
+                Task.Delay(5).Wait();
+                Close();
+                if(Open())
+                {
+                    OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
+                }
+            });
         }
 
         public bool Send(string message)
@@ -199,6 +204,10 @@ namespace TwitchLib.Communication.Clients
                     try
                     {
                         var input = await _reader.ReadLineAsync();
+
+                        if (input is null)
+                            Send("PING");
+                        
                         OnMessage?.Invoke(this, new OnMessageEventArgs {Message = input});
                     }
                     catch (Exception ex)

--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -205,8 +205,11 @@ namespace TwitchLib.Communication.Clients
                     {
                         var input = await _reader.ReadLineAsync();
 
-                        if (input is null)
+                        if (input is null && IsConnected)
+                        {
                             Send("PING");
+                            Task.Delay(500).Wait();
+                        }
                         
                         OnMessage?.Invoke(this, new OnMessageEventArgs {Message = input});
                     }

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -105,11 +105,15 @@ namespace TwitchLib.Communication.Clients
         
         public void Reconnect()
         {
-            Close();
-            if(Open())
+            Task.Run(() =>
             {
-                OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
-            }
+                Task.Delay(5).Wait();
+                Close();
+                if(Open())
+                {
+                    OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
+                }
+            });
         }
         
         public bool Send(string message)


### PR DESCRIPTION
Fixing the reconnect, since it was not working/reconnecting to TCP Client.
Running the main Reconnect() methode in inside a Task to apply an Task.Delay of about 5 ms, wait for it to complete and then reconnect(). This should give the programm a little buffer so that the necessary rest can be executed.

For TCP Client ListenerTask, also check if the input is null, if so Send a PING to the Server to get new Client?.Connected information, since it only shows the last state and it refreshes with a PING. (IsConnected = true, while the private _isConnected from TCP Client = false, and _isDisconnected = true) [See here](https://julandealb.github.io/pictures/TwitchLibError.png)