### PR TITLE
Rare reconnecting error and Reconnect after internet loss

### DIFF
--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -239,7 +239,7 @@ namespace TwitchLib.Communication.Clients
                             if (!IsConnected)
                                 notConnectedCounter++;
                             
-                            else if (notConnectedCounter >= 50)
+                            else if (notConnectedCounter >= 25)
                                 Reconnect();
                             
                             else if (notConnectedCounter != 0 && IsConnected)

--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -16,6 +16,7 @@ namespace TwitchLib.Communication.Clients
 {
     public class TcpClient : IClient
     {
+        private int NotConnectedCounter;
         public TimeSpan DefaultKeepAliveInterval { get; set; }
         public int SendQueueLength => _throttlers.SendQueue.Count;
         public int WhisperQueueLength => _throttlers.WhisperQueue.Count;
@@ -226,7 +227,7 @@ namespace TwitchLib.Communication.Clients
             return Task.Run(() =>
             {
                 var needsReconnect = false;
-                var notConnectedCounter = 0;
+                var checkConnectedCounter = 0;
                 try
                 {
                     var lastState = IsConnected;
@@ -237,14 +238,36 @@ namespace TwitchLib.Communication.Clients
                             Thread.Sleep(200);
 
                             if (!IsConnected)
-                                notConnectedCounter++;
+                                NotConnectedCounter++;
+                            else
+                                checkConnectedCounter++;
                             
-                            else if (notConnectedCounter >= 25)
-                                Reconnect();
+                            if (checkConnectedCounter >= 300) //Check every 60s for Response
+                            {
+                                Send("PING");
+                                checkConnectedCounter = 0;
+                            }
                             
-                            else if (notConnectedCounter != 0 && IsConnected)
-                                notConnectedCounter = 0;
+                            switch (NotConnectedCounter)
+                            {
+                                case 25: //Try Reconnect after 5s
+                                case 75: //Try Reconnect after extra 10s
+                                case 150: //Try Reconnect after extra 15s
+                                case 300: //Try Reconnect after extra 30s
+                                case 600: //Try Reconnect after extra 60s
+                                    Reconnect();
+                                    break;
+                                default:
+                                {
+                                    if (NotConnectedCounter >= 1200 && NotConnectedCounter % 600 == 0) //Try Reconnect after every 120s from this point
+                                        Reconnect();
+                                    break;
+                                }
+                            }
                             
+                            if (NotConnectedCounter != 0 && IsConnected)
+                                NotConnectedCounter = 0;
+                                
                             continue;
                         }
                         OnStateChanged?.Invoke(this, new OnStateChangedEventArgs { IsConnected = IsConnected, WasConnected = lastState });

--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -122,7 +122,7 @@ namespace TwitchLib.Communication.Clients
         {
             Task.Run(() =>
             {
-                Task.Delay(5).Wait();
+                Task.Delay(20).Wait();
                 Close();
                 if(Open())
                 {
@@ -226,6 +226,7 @@ namespace TwitchLib.Communication.Clients
             return Task.Run(() =>
             {
                 var needsReconnect = false;
+                var notConnectedCounter = 0;
                 try
                 {
                     var lastState = IsConnected;
@@ -234,6 +235,16 @@ namespace TwitchLib.Communication.Clients
                         if (lastState == IsConnected)
                         {
                             Thread.Sleep(200);
+
+                            if (!IsConnected)
+                                notConnectedCounter++;
+                            
+                            else if (notConnectedCounter >= 50)
+                                Reconnect();
+                            
+                            else if (notConnectedCounter != 0 && IsConnected)
+                                notConnectedCounter = 0;
+                            
                             continue;
                         }
                         OnStateChanged?.Invoke(this, new OnStateChangedEventArgs { IsConnected = IsConnected, WasConnected = lastState });

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -107,7 +107,7 @@ namespace TwitchLib.Communication.Clients
         {
             Task.Run(() =>
             {
-                Task.Delay(5).Wait();
+                Task.Delay(20).Wait();
                 Close();
                 if(Open())
                 {
@@ -227,6 +227,7 @@ namespace TwitchLib.Communication.Clients
             return Task.Run(() =>
             {
                 var needsReconnect = false;
+                var notConnectedCounter = 0;
                 try
                 {
                     var lastState = IsConnected;
@@ -235,6 +236,16 @@ namespace TwitchLib.Communication.Clients
                         if (lastState == IsConnected)
                         {
                             Thread.Sleep(200);
+
+                            if (!IsConnected)
+                                notConnectedCounter++;
+                            
+                            else if (notConnectedCounter >= 50)
+                                Reconnect();
+                            
+                            else if (notConnectedCounter != 0 && IsConnected)
+                                notConnectedCounter = 0;
+                            
                             continue;
                         }
                         OnStateChanged?.Invoke(this, new OnStateChangedEventArgs { IsConnected = Client.State == WebSocketState.Open, WasConnected = lastState});

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -240,7 +240,7 @@ namespace TwitchLib.Communication.Clients
                             if (!IsConnected)
                                 notConnectedCounter++;
                             
-                            else if (notConnectedCounter >= 50)
+                            else if (notConnectedCounter >= 25)
                                 Reconnect();
                             
                             else if (notConnectedCounter != 0 && IsConnected)


### PR DESCRIPTION
This should fix a rare reconnecting issue, where the IClient IsConnected will never be true and will not try to reconnect since lastState and IsConnected is allways true which continues the while loop. Even if it would continue, it wont set needsReconnect to true because _stopServices stays true.

To fix it i added a counter, when the counter hits 25 (which means the IClient isnt connected since 6 Seconds, it will do a Reconnect(), else it would reset the counter

And i increased the delay on the Reconnect() method from 5ms to 20ms to give it a little more time.