### PR TITLE
fix-suggestion for "Automatic reconnect after disconnect #206"

### DIFF
--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -97,24 +97,24 @@ namespace TwitchLib.Communication.Clients
                 if (IsConnected) return true;
 
                 Task.Run(() => { 
-                InitializeClient();
-                Client.Connect(_server, Port);
-                if (Options.UseSsl)
-                {
-                    var ssl = new SslStream(Client.GetStream(), false);
-                    ssl.AuthenticateAsClient(_server);
-                    _reader = new StreamReader(ssl);
-                    _writer = new StreamWriter(ssl);
-                }
-                else
-                {
-                    _reader = new StreamReader(Client.GetStream());
-                    _writer = new StreamWriter(Client.GetStream());
-                }
+                    InitializeClient();
+                    Client.Connect(_server, Port);
+                    if (Options.UseSsl)
+                    {
+                        var ssl = new SslStream(Client.GetStream(), false);
+                        ssl.AuthenticateAsClient(_server);
+                        _reader = new StreamReader(ssl);
+                        _writer = new StreamWriter(ssl);
+                    }
+                    else
+                    {
+                        _reader = new StreamReader(Client.GetStream());
+                        _writer = new StreamWriter(Client.GetStream());
+                    }
                 }).Wait(10000);
 
                 if (!IsConnected) return _Open();
-                
+
                 StartNetworkServices();
                 return true;
 
@@ -246,7 +246,7 @@ namespace TwitchLib.Communication.Clients
                             Send("PING");
                             Task.Delay(500).Wait();
                         }
-                        
+
                         OnMessage?.Invoke(this, new OnMessageEventArgs {Message = input});
                     }
                     catch (Exception ex)
@@ -276,13 +276,13 @@ namespace TwitchLib.Communication.Clients
                                 NotConnectedCounter++;
                             else
                                 checkConnectedCounter++;
-                            
+
                             if (checkConnectedCounter >= 300) //Check every 60s for Response
                             {
                                 Send("PING");
                                 checkConnectedCounter = 0;
                             }
-                            
+
                             switch (NotConnectedCounter)
                             {
                                 case 25: //Try Reconnect after 5s
@@ -290,19 +290,19 @@ namespace TwitchLib.Communication.Clients
                                 case 150: //Try Reconnect after extra 15s
                                 case 300: //Try Reconnect after extra 30s
                                 case 600: //Try Reconnect after extra 60s
-                                    Reconnect();
+                                    _Reconnect();
                                     break;
                                 default:
-                                {
-                                    if (NotConnectedCounter >= 1200 && NotConnectedCounter % 600 == 0) //Try Reconnect after every 120s from this point
-                                        Reconnect();
-                                    break;
-                                }
+                                    {
+                                        if (NotConnectedCounter >= 1200 && NotConnectedCounter % 600 == 0) //Try Reconnect after every 120s from this point
+                                            _Reconnect();
+                                        break;
+                                    }
                             }
-                            
+
                             if (NotConnectedCounter != 0 && IsConnected)
                                 NotConnectedCounter = 0;
-                                
+
                             continue;
                         }
                         OnStateChanged?.Invoke(this, new OnStateChangedEventArgs { IsConnected = IsConnected, WasConnected = lastState });
@@ -329,7 +329,7 @@ namespace TwitchLib.Communication.Clients
                 }
 
                 if (needsReconnect && !_stopServices)
-                    Reconnect();
+                    _Reconnect();
             }, _tokenSource.Token);
         }
 
@@ -354,7 +354,7 @@ namespace TwitchLib.Communication.Clients
             //_throttlers.Reconnecting = false;
             //_networkServicesRunning = false;
         }
-        
+
         private void Reset()
         {
             this._stopServices = false;

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -63,6 +63,9 @@ namespace TwitchLib.Communication.Clients
 
         private void InitializeClient()
         {
+            // check if services should stop
+            if (this._stopServices) { return; }
+
             Client?.Abort();
             Client = new ClientWebSocket();
             
@@ -74,16 +77,29 @@ namespace TwitchLib.Communication.Clients
 
             if (_monitorTask.IsCompleted) _monitorTask = StartMonitorTask();
         }
-
-        public bool Open()
+        public bool Open() {
+            // reset some boolean values
+            // especially _stopServices
+            this.Reset();
+            // now using private _Open()
+            return this._Open();
+        }
+        /// <summary>
+        ///     for private use only,
+        ///     to be able to check <see cref="_stopServices"/> at the beginning
+        /// </summary>
+        private bool _Open()
         {
+            // check if services should stop
+            if (this._stopServices) { return false; }
+
             try
             {
                 if (IsConnected) return true;
 
                 InitializeClient();
                 Client.ConnectAsync(new Uri(Url), _tokenSource.Token).Wait(10000);
-                if (!IsConnected) return Open();
+                if (!IsConnected) return _Open();
                 
                 StartNetworkServices();
                 return true;
@@ -106,14 +122,27 @@ namespace TwitchLib.Communication.Clients
             
             OnDisconnected?.Invoke(this, new OnDisconnectedEventArgs());
         }
-        
-        public void Reconnect()
+        public void Reconnect() {
+            // reset some boolean values
+            // especially _stopServices
+            this.Reset();
+            // now using private _Reconnect()
+            this._Reconnect();
+        }
+        /// <summary>
+        ///     for private use only,
+        ///     to be able to check <see cref="_stopServices"/> at the beginning
+        /// </summary>
+        private void _Reconnect()
         {
+            // check if services should stop
+            if (this._stopServices) { return; }
+
             Task.Run(() =>
             {
                 Task.Delay(20).Wait();
                 Close();
-                if(Open())
+                if(_Open())
                 {
                     OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
                 }
@@ -259,12 +288,12 @@ namespace TwitchLib.Communication.Clients
                                 case 150: //Try Reconnect after extra 15s
                                 case 300: //Try Reconnect after extra 30s
                                 case 600: //Try Reconnect after extra 60s
-                                    Reconnect();
+                                    _Reconnect();
                                     break;
                                 default:
                                 {
                                     if (NotConnectedCounter >= 1200 && NotConnectedCounter % 600 == 0) //Try Reconnect after every 120s from this point
-                                        Reconnect();
+                                            _Reconnect();
                                     break;
                                 }
                             }
@@ -301,7 +330,7 @@ namespace TwitchLib.Communication.Clients
                 }
 
                 if (needsReconnect && !_stopServices)
-                    Reconnect();
+                    _Reconnect();
             }, _tokenSource.Token);
         }
 
@@ -320,11 +349,16 @@ namespace TwitchLib.Communication.Clients
                 {
                     Reason = "Fatal network error. Network services fail to shut down."
                 });
-            _stopServices = false;
-            _throttlers.Reconnecting = false;
-            _networkServicesRunning = false;
+            // moved to Reset()
+            //_stopServices = false;
+            //_throttlers.Reconnecting = false;
+            //_networkServicesRunning = false;
         }
-       
+        private void Reset() {
+            this._stopServices = false;
+            this._throttlers.Reconnecting = false;
+            this._networkServicesRunning = false;
+        }
         public void WhisperThrottled(OnWhisperThrottledEventArgs eventArgs)
         {
             OnWhisperThrottled?.Invoke(this, eventArgs);

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -77,13 +77,15 @@ namespace TwitchLib.Communication.Clients
 
             if (_monitorTask.IsCompleted) _monitorTask = StartMonitorTask();
         }
-        public bool Open() {
+        public bool Open()
+        {
             // reset some boolean values
             // especially _stopServices
             this.Reset();
             // now using private _Open()
             return this._Open();
         }
+
         /// <summary>
         ///     for private use only,
         ///     to be able to check <see cref="_stopServices"/> at the beginning
@@ -122,13 +124,16 @@ namespace TwitchLib.Communication.Clients
             
             OnDisconnected?.Invoke(this, new OnDisconnectedEventArgs());
         }
-        public void Reconnect() {
+
+        public void Reconnect()
+        {
             // reset some boolean values
             // especially _stopServices
             this.Reset();
             // now using private _Reconnect()
             this._Reconnect();
         }
+
         /// <summary>
         ///     for private use only,
         ///     to be able to check <see cref="_stopServices"/> at the beginning
@@ -349,16 +354,20 @@ namespace TwitchLib.Communication.Clients
                 {
                     Reason = "Fatal network error. Network services fail to shut down."
                 });
+
             // moved to Reset()
             //_stopServices = false;
             //_throttlers.Reconnecting = false;
             //_networkServicesRunning = false;
         }
-        private void Reset() {
+        
+        private void Reset()
+        {
             this._stopServices = false;
             this._throttlers.Reconnecting = false;
             this._networkServicesRunning = false;
         }
+
         public void WhisperThrottled(OnWhisperThrottledEventArgs eventArgs)
         {
             OnWhisperThrottled?.Invoke(this, eventArgs);


### PR DESCRIPTION
this pull request addresses the following issue
https://github.com/TwitchLib/TwitchLib.Client/issues/206
and is just a suggestion


it targets `TcpClient` and `WebsocketClient`

the methods `Reconnect()` and `Open()` became a private pendant `_Reconnect()` and `_Open()`
those private Methods check the state of the private variable `_stopServices` before they perceed

a new private method `Reset()` is introduced
this methods resets the following private variables to `false`

- `_stopServices`
- `_throttlers.Reconnecting`
- `_networkServicesRunning`

and is used within the public methods `Reconnect()` and `Open()`


my thought was/is, to keep, espacially `_stopServices` value, 'as long as possible' `false` to avoid reconnects open while shutting down everything