### PR TITLE
fixing reconnect-issues

### DIFF
--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -347,11 +347,6 @@ namespace TwitchLib.Communication.Clients
                 {
                     Reason = "Fatal network error. Network services fail to shut down."
                 });
-
-            // moved to Reset()
-            //_stopServices = false;
-            //_throttlers.Reconnecting = false;
-            //_networkServicesRunning = false;
         }
 
         private void Reset()

--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -155,15 +155,10 @@ namespace TwitchLib.Communication.Clients
             // check if services should stop
             if (_stopServices) return;
 
-            Task.Run(() =>
+            if (_Open())
             {
-                Task.Delay(20).Wait();
-                Close();
-                if(_Open())
-                {
-                    OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
-                }
-            });
+                OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
+            }
         }
 
         public bool Send(string message)

--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -139,6 +139,9 @@ namespace TwitchLib.Communication.Clients
 
         public void Reconnect()
         {
+            if (IsConnected) Close();
+            // to ensure, everythings closed
+            Task.Delay(TimeSpan.FromSeconds(3)).Wait();
             // reset some boolean values
             // especially _stopServices
             Reset();

--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Net.Security;
-using System.Net.Sockets;
-using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
+
 using TwitchLib.Communication.Events;
 using TwitchLib.Communication.Interfaces;
 using TwitchLib.Communication.Models;
@@ -61,7 +59,7 @@ namespace TwitchLib.Communication.Clients
         private void InitializeClient()
         {
             // check if services should stop
-            if (this._stopServices) { return; }
+            if (_stopServices) return;
 
             Client = new System.Net.Sockets.TcpClient();
 
@@ -78,9 +76,9 @@ namespace TwitchLib.Communication.Clients
         {
             // reset some boolean values
             // especially _stopServices
-            this.Reset();
+            Reset();
             // now using private _Open()
-            return this._Open();
+            return _Open();
         }
 
         /// <summary>
@@ -90,18 +88,19 @@ namespace TwitchLib.Communication.Clients
         private bool _Open()
         {
             // check if services should stop
-            if (this._stopServices) { return false; }
+            if (_stopServices) return false;
 
             try
             {
                 if (IsConnected) return true;
 
-                Task.Run(() => { 
+                Task.Run(() =>
+                {
                     InitializeClient();
                     Client.Connect(_server, Port);
                     if (Options.UseSsl)
                     {
-                        var ssl = new SslStream(Client.GetStream(), false);
+                        SslStream ssl = new SslStream(Client.GetStream(), false);
                         ssl.AuthenticateAsClient(_server);
                         _reader = new StreamReader(ssl);
                         _writer = new StreamWriter(ssl);
@@ -142,9 +141,9 @@ namespace TwitchLib.Communication.Clients
         {
             // reset some boolean values
             // especially _stopServices
-            this.Reset();
+            Reset();
             // now using private _Reconnect()
-            this._Reconnect();
+            _Reconnect();
         }
 
         /// <summary>
@@ -154,7 +153,7 @@ namespace TwitchLib.Communication.Clients
         private void _Reconnect()
         {
             // check if services should stop
-            if (this._stopServices) { return; }
+            if (_stopServices) return;
 
             Task.Run(() =>
             {
@@ -182,7 +181,7 @@ namespace TwitchLib.Communication.Clients
             }
             catch (Exception ex)
             {
-                OnError?.Invoke(this, new OnErrorEventArgs {Exception = ex});
+                OnError?.Invoke(this, new OnErrorEventArgs { Exception = ex });
                 throw;
             }
         }
@@ -202,7 +201,7 @@ namespace TwitchLib.Communication.Clients
             }
             catch (Exception ex)
             {
-                OnError?.Invoke(this, new OnErrorEventArgs {Exception = ex});
+                OnError?.Invoke(this, new OnErrorEventArgs { Exception = ex });
                 throw;
             }
         }
@@ -239,7 +238,7 @@ namespace TwitchLib.Communication.Clients
                 {
                     try
                     {
-                        var input = await _reader.ReadLineAsync();
+                        string input = await _reader.ReadLineAsync();
 
                         if (input is null && IsConnected)
                         {
@@ -247,11 +246,11 @@ namespace TwitchLib.Communication.Clients
                             Task.Delay(500).Wait();
                         }
 
-                        OnMessage?.Invoke(this, new OnMessageEventArgs {Message = input});
+                        OnMessage?.Invoke(this, new OnMessageEventArgs { Message = input });
                     }
                     catch (Exception ex)
                     {
-                        OnError?.Invoke(this, new OnErrorEventArgs {Exception = ex});
+                        OnError?.Invoke(this, new OnErrorEventArgs { Exception = ex });
                     }
                 }
             });
@@ -261,11 +260,11 @@ namespace TwitchLib.Communication.Clients
         {
             return Task.Run(() =>
             {
-                var needsReconnect = false;
-                var checkConnectedCounter = 0;
+                bool needsReconnect = false;
+                int checkConnectedCounter = 0;
                 try
                 {
-                    var lastState = IsConnected;
+                    bool lastState = IsConnected;
                     while (!_tokenSource.IsCancellationRequested)
                     {
                         if (lastState == IsConnected)
@@ -325,7 +324,7 @@ namespace TwitchLib.Communication.Clients
                 }
                 catch (Exception ex)
                 {
-                    OnError?.Invoke(this, new OnErrorEventArgs {Exception = ex});
+                    OnError?.Invoke(this, new OnErrorEventArgs { Exception = ex });
                 }
 
                 if (needsReconnect && !_stopServices)
@@ -357,9 +356,9 @@ namespace TwitchLib.Communication.Clients
 
         private void Reset()
         {
-            this._stopServices = false;
-            this._throttlers.Reconnecting = false;
-            this._networkServicesRunning = false;
+            _stopServices = false;
+            _throttlers.Reconnecting = false;
+            _networkServicesRunning = false;
         }
 
         public void WhisperThrottled(OnWhisperThrottledEventArgs eventArgs)

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -128,6 +128,9 @@ namespace TwitchLib.Communication.Clients
 
         public void Reconnect()
         {
+            if (IsConnected) Close();
+            // to ensure, everythings closed
+            Task.Delay(TimeSpan.FromSeconds(3)).Wait();
             // reset some boolean values
             // especially _stopServices
             Reset();

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -4,6 +4,7 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
 using TwitchLib.Communication.Enums;
 using TwitchLib.Communication.Events;
 using TwitchLib.Communication.Interfaces;
@@ -64,7 +65,7 @@ namespace TwitchLib.Communication.Clients
         private void InitializeClient()
         {
             // check if services should stop
-            if (this._stopServices) { return; }
+            if (_stopServices) return;
 
             Client?.Abort();
             Client = new ClientWebSocket();
@@ -81,9 +82,9 @@ namespace TwitchLib.Communication.Clients
         {
             // reset some boolean values
             // especially _stopServices
-            this.Reset();
+            Reset();
             // now using private _Open()
-            return this._Open();
+            return _Open();
         }
 
         /// <summary>
@@ -93,7 +94,7 @@ namespace TwitchLib.Communication.Clients
         private bool _Open()
         {
             // check if services should stop
-            if (this._stopServices) { return false; }
+            if (_stopServices) return false;
 
             try
             {
@@ -129,9 +130,9 @@ namespace TwitchLib.Communication.Clients
         {
             // reset some boolean values
             // especially _stopServices
-            this.Reset();
+            Reset();
             // now using private _Reconnect()
-            this._Reconnect();
+            _Reconnect();
         }
 
         /// <summary>
@@ -141,7 +142,7 @@ namespace TwitchLib.Communication.Clients
         private void _Reconnect()
         {
             // check if services should stop
-            if (this._stopServices) { return; }
+            if (_stopServices) return;
 
             Task.Run(() =>
             {
@@ -218,12 +219,12 @@ namespace TwitchLib.Communication.Clients
         {
             return Task.Run(async () =>
             {
-                var message = "";
+                string message = "";
 
                 while (IsConnected && _networkServicesRunning)
                 {
                     WebSocketReceiveResult result;
-                    var buffer = new byte[1024];
+                    byte[] buffer = new byte[1024];
 
                     try
                     {
@@ -247,7 +248,7 @@ namespace TwitchLib.Communication.Clients
                             continue;
                         case WebSocketMessageType.Text:
                             message += Encoding.UTF8.GetString(buffer).TrimEnd('\0');
-                            OnMessage?.Invoke(this, new OnMessageEventArgs(){Message = message});
+                            OnMessage?.Invoke(this, new OnMessageEventArgs() { Message = message });
                             break;
                         case WebSocketMessageType.Binary:
                             break;
@@ -264,11 +265,11 @@ namespace TwitchLib.Communication.Clients
         {
             return Task.Run(() =>
             {
-                var needsReconnect = false;
-                var checkConnectedCounter = 0;
+                bool needsReconnect = false;
+                int checkConnectedCounter = 0;
                 try
                 {
-                    var lastState = IsConnected;
+                    bool lastState = IsConnected;
                     while (!_tokenSource.IsCancellationRequested)
                     {
                         if (lastState == IsConnected)
@@ -308,7 +309,7 @@ namespace TwitchLib.Communication.Clients
                                 
                             continue;
                         }
-                        OnStateChanged?.Invoke(this, new OnStateChangedEventArgs { IsConnected = Client.State == WebSocketState.Open, WasConnected = lastState});
+                        OnStateChanged?.Invoke(this, new OnStateChangedEventArgs { IsConnected = Client.State == WebSocketState.Open, WasConnected = lastState });
 
                         if (IsConnected)
                             OnConnected?.Invoke(this, new OnConnectedEventArgs());
@@ -348,7 +349,7 @@ namespace TwitchLib.Communication.Clients
             if (!_stopServices) return;
             if (!(_networkTasks?.Length > 0)) return;
             if (Task.WaitAll(_networkTasks, 15000)) return;
-           
+
             OnFatality?.Invoke(this,
                 new OnFatalErrorEventArgs
                 {
@@ -363,9 +364,9 @@ namespace TwitchLib.Communication.Clients
         
         private void Reset()
         {
-            this._stopServices = false;
-            this._throttlers.Reconnecting = false;
-            this._networkServicesRunning = false;
+            _stopServices = false;
+            _throttlers.Reconnecting = false;
+            _networkServicesRunning = false;
         }
 
         public void WhisperThrottled(OnWhisperThrottledEventArgs eventArgs)

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -42,7 +42,7 @@ namespace TwitchLib.Communication.Clients
         private bool _networkServicesRunning;
         private Task[] _networkTasks;
         private Task _monitorTask;
-        
+
         public WebSocketClient(IClientOptions options = null)
         {
             Options = options ?? new ClientOptions();
@@ -69,7 +69,7 @@ namespace TwitchLib.Communication.Clients
 
             Client?.Abort();
             Client = new ClientWebSocket();
-            
+
             if (_monitorTask == null)
             {
                 _monitorTask = StartMonitorTask();
@@ -103,7 +103,7 @@ namespace TwitchLib.Communication.Clients
                 InitializeClient();
                 Client.ConnectAsync(new Uri(Url), _tokenSource.Token).Wait(10000);
                 if (!IsConnected) return _Open();
-                
+
                 StartNetworkServices();
                 return true;
             }
@@ -119,10 +119,10 @@ namespace TwitchLib.Communication.Clients
             Client?.Abort();
             _stopServices = callDisconnect;
             CleanupServices();
-            
+
             if (!callDisconnect)
                 InitializeClient();
-            
+
             OnDisconnected?.Invoke(this, new OnDisconnectedEventArgs());
         }
 
@@ -145,10 +145,10 @@ namespace TwitchLib.Communication.Clients
             if (_stopServices) return;
             if (_Open())
             {
-                    OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
-                }
+                OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
+            }
         }
-        
+
         public bool Send(string message)
         {
             try
@@ -168,7 +168,7 @@ namespace TwitchLib.Communication.Clients
                 throw;
             }
         }
-        
+
         public bool SendWhisper(string message)
         {
             try
@@ -188,7 +188,7 @@ namespace TwitchLib.Communication.Clients
                 throw;
             }
         }
-        
+
         private void StartNetworkServices()
         {
             _networkServicesRunning = true;
@@ -249,7 +249,7 @@ namespace TwitchLib.Communication.Clients
                         default:
                             throw new ArgumentOutOfRangeException();
                     }
-                    
+
                     message = "";
                 }
             });
@@ -274,13 +274,13 @@ namespace TwitchLib.Communication.Clients
                                 NotConnectedCounter++;
                             else
                                 checkConnectedCounter++;
-                            
+
                             if (checkConnectedCounter >= 300) //Check every 60s for Response
                             {
                                 Send("PING");
                                 checkConnectedCounter = 0;
                             }
-                            
+
                             switch (NotConnectedCounter)
                             {
                                 case 25: //Try Reconnect after 5s
@@ -291,16 +291,16 @@ namespace TwitchLib.Communication.Clients
                                     _Reconnect();
                                     break;
                                 default:
-                                {
-                                    if (NotConnectedCounter >= 1200 && NotConnectedCounter % 600 == 0) //Try Reconnect after every 120s from this point
+                                    {
+                                        if (NotConnectedCounter >= 1200 && NotConnectedCounter % 600 == 0) //Try Reconnect after every 120s from this point
                                             _Reconnect();
-                                    break;
-                                }
+                                        break;
+                                    }
                             }
-                            
+
                             if (NotConnectedCounter != 0 && IsConnected)
                                 NotConnectedCounter = 0;
-                                
+
                             continue;
                         }
                         OnStateChanged?.Invoke(this, new OnStateChangedEventArgs { IsConnected = Client.State == WebSocketState.Open, WasConnected = lastState });
@@ -315,7 +315,7 @@ namespace TwitchLib.Communication.Clients
                                 needsReconnect = true;
                                 break;
                             }
-                            
+
                             OnDisconnected?.Invoke(this, new OnDisconnectedEventArgs());
                             if (Client.CloseStatus != null && Client.CloseStatus != WebSocketCloseStatus.NormalClosure)
                                 OnError?.Invoke(this, new OnErrorEventArgs { Exception = new Exception(Client.CloseStatus + " " + Client.CloseStatusDescription) });
@@ -339,7 +339,7 @@ namespace TwitchLib.Communication.Clients
             _tokenSource.Cancel();
             _tokenSource = new CancellationTokenSource();
             _throttlers.TokenSource = _tokenSource;
-            
+
             if (!_stopServices) return;
             if (!(_networkTasks?.Length > 0)) return;
             if (Task.WaitAll(_networkTasks, 15000)) return;
@@ -350,7 +350,7 @@ namespace TwitchLib.Communication.Clients
                     Reason = "Fatal network error. Network services fail to shut down."
                 });
         }
-        
+
         private void Reset()
         {
             _stopServices = false;

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -143,16 +143,10 @@ namespace TwitchLib.Communication.Clients
         {
             // check if services should stop
             if (_stopServices) return;
-
-            Task.Run(() =>
+            if (_Open())
             {
-                Task.Delay(20).Wait();
-                Close();
-                if(_Open())
-                {
                     OnReconnected?.Invoke(this, new OnReconnectedEventArgs());
                 }
-            });
         }
         
         public bool Send(string message)

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -355,11 +355,6 @@ namespace TwitchLib.Communication.Clients
                 {
                     Reason = "Fatal network error. Network services fail to shut down."
                 });
-
-            // moved to Reset()
-            //_stopServices = false;
-            //_throttlers.Reconnecting = false;
-            //_networkServicesRunning = false;
         }
         
         private void Reset()


### PR DESCRIPTION
this pullrequest still addresses the following issues

https://github.com/TwitchLib/TwitchLib/issues/1093
https://github.com/TwitchLib/TwitchLib.Client/issues/206
https://github.com/TwitchLib/TwitchLib/issues/1104

it still targest `WebsocketClient` and `TcpClient`


the "code formatting" commits depend upon my editorconfig. i tried to configure it the right way, but... - sorry

within the "removed comment" commits, i removed the comment, where code went to

the important commits are "no task and dont close() again" and "no task needed and dont close() again":

in my mind, no task is needed to call `_Open()` again
the bug, that @WrithemTwine detected https://github.com/TwitchLib/TwitchLib/issues/1093#issuecomment-1444301612
was triggered by the call to `Close()` within `_Reconnect()`
