### PR TITLE
Async/Await refactoring

### DIFF
--- a/src/TwitchLib.Communication.Tests/Clients/ClientTestsBase.cs
+++ b/src/TwitchLib.Communication.Tests/Clients/ClientTestsBase.cs
@@ -24,33 +24,33 @@ namespace TwitchLib.Communication.Tests.Clients
     /// </typeparam>
     public abstract class ClientTestsBase<T> where T : IClient
     {
-        private static uint WaitAfterDispose => 3;
         private static TimeSpan WaitOneDuration => TimeSpan.FromSeconds(5);
-        private static IClientOptions Options;
+        private readonly IClientOptions? _options;
 
-        public ClientTestsBase(IClientOptions options = null)
+        protected ClientTestsBase(IClientOptions? options = null)
         {
-            Options = options;
+            _options = options;
         }
         
         [Fact]
-        public void Client_Raises_OnConnected_EventArgs()
+        public async Task Client_Raises_OnConnected_EventArgs()
         {
             // create one logger per test-method! - cause one file per test-method is generated
-            ILogger<T> logger = TestLogHelper.GetLogger<T>();
-            T? client = GetClient(logger, Options);
+            var logger = TestLogHelper.GetLogger<T>();
+            var client = GetClient(logger, _options);
             Assert.NotNull(client);
             try
             {
-                ManualResetEvent pauseConnected = new ManualResetEvent(false);
+                var pauseConnected = new ManualResetEvent(false);
 
-                Assert.Raises<OnConnectedEventArgs>(
+                await Assert.RaisesAsync<OnConnectedEventArgs>(
                     h => client.OnConnected += h,
                     h => client.OnConnected -= h,
-                    () =>
+                    async () =>
                     {
                         client.OnConnected += (sender, e) => pauseConnected.Set();
-                        client.Open();
+                        await client.OpenAsync();
+                        
                         Assert.True(pauseConnected.WaitOne(WaitOneDuration));
                     });
             }
@@ -61,33 +61,34 @@ namespace TwitchLib.Communication.Tests.Clients
             }
             finally
             {
-                Cleanup(client);
+                client.Dispose();
             }
         }
 
         [Fact]
-        public void Client_Raises_OnDisconnected_EventArgs()
+        public async Task Client_Raises_OnDisconnected_EventArgs()
         {
             // create one logger per test-method! - cause one file per test-method is generated
-            ILogger<T> logger = TestLogHelper.GetLogger<T>();
-            T? client = GetClient(logger, Options);
+            var logger = TestLogHelper.GetLogger<T>();
+            var client = GetClient(logger, _options);
             Assert.NotNull(client);
             try
             {
-                ManualResetEvent pauseDisconnected = new ManualResetEvent(false);
+                var pauseDisconnected = new ManualResetEvent(false);
 
-                Assert.Raises<OnDisconnectedEventArgs>(
+                await Assert.RaisesAsync<OnDisconnectedEventArgs>(
                     h => client.OnDisconnected += h,
                     h => client.OnDisconnected -= h,
-                    () =>
+                    async () =>
                     {
-                        client.OnConnected += (sender, e) =>
+                        client.OnConnected += async (sender, e) =>
                         {
-                            Task.Delay(WaitOneDuration).GetAwaiter().GetResult();
-                            client.Close();
+                            await client.CloseAsync();
                         };
+                        
                         client.OnDisconnected += (sender, e) => pauseDisconnected.Set();
-                        client.Open();
+                        await client.OpenAsync();
+                        
                         Assert.True(pauseDisconnected.WaitOne(WaitOneDuration));
                     });
             }
@@ -98,30 +99,30 @@ namespace TwitchLib.Communication.Tests.Clients
             }
             finally
             {
-                Cleanup(client);
+                client.Dispose();
             }
         }
 
         [Fact]
-        public void Client_Raises_OnReconnected_EventArgs()
+        public async Task Client_Raises_OnReconnected_EventArgs()
         {
             // create one logger per test-method! - cause one file per test-method is generated
-            ILogger<T> logger = TestLogHelper.GetLogger<T>();
-            T? client = GetClient(logger, Options);
+            var logger = TestLogHelper.GetLogger<T>();
+            var client = GetClient(logger, _options);
             Assert.NotNull(client);
             try
             {
-                ManualResetEvent pauseReconnected = new ManualResetEvent(false);
+                var pauseReconnected = new ManualResetEvent(false);
 
-                Assert.Raises<OnConnectedEventArgs>(
+                await Assert.RaisesAsync<OnConnectedEventArgs>(
                     h => client.OnReconnected += h,
                     h => client.OnReconnected -= h,
-                    () =>
+                    async () =>
                     {
-                        client.OnConnected += (s, e) => client.Reconnect();
+                        client.OnConnected += async (s, e) => await client.ReconnectAsync();
 
                         client.OnReconnected += (s, e) => pauseReconnected.Set();
-                        client.Open();
+                        await client.OpenAsync();
 
                         Assert.True(pauseReconnected.WaitOne(WaitOneDuration));
                     });
@@ -133,7 +134,7 @@ namespace TwitchLib.Communication.Tests.Clients
             }
             finally
             {
-                Cleanup(client);
+                client.Dispose();
             }
         }
 
@@ -141,11 +142,11 @@ namespace TwitchLib.Communication.Tests.Clients
         public void Dispose_Client_Before_Connecting_IsOK()
         {
             // create one logger per test-method! - cause one file per test-method is generated
-            ILogger<T> logger = TestLogHelper.GetLogger<T>();
+            var logger = TestLogHelper.GetLogger<T>();
             IClient? client = null;
             try
             {
-                client = GetClient(logger, Options);
+                client = GetClient(logger, _options);
                 Assert.NotNull(client);
                 client.Dispose();
             }
@@ -156,29 +157,25 @@ namespace TwitchLib.Communication.Tests.Clients
             }
             finally
             {
-                Cleanup((T?)client);
+                client?.Dispose();
             }
-        }
-
-        private static void Cleanup(T? client)
-        {
-            client?.Dispose();
-            Task.Delay(TimeSpan.FromSeconds(WaitAfterDispose)).GetAwaiter().GetResult();
         }
 
         private static TClient? GetClient<TClient>(ILogger<TClient> logger, IClientOptions? options = null)
         {
-            Type[] constructorParameterTypes = new Type[]
+            var constructorParameterTypes = new Type[]
             {
                 typeof(IClientOptions),
                 typeof(ILogger<TClient>)
             };
-            ConstructorInfo? constructor = typeof(TClient).GetConstructor(constructorParameterTypes);
-            object[] constructorParameters = new object[]
+            
+            var constructor = typeof(TClient).GetConstructor(constructorParameterTypes);
+            var constructorParameters = new object[]
             {
                 options ?? new ClientOptions(),
                 logger
             };
+            
             return (TClient?)constructor?.Invoke(constructorParameters);
         }
     }

--- a/src/TwitchLib.Communication.Tests/Clients/ClientTestsBase.cs
+++ b/src/TwitchLib.Communication.Tests/Clients/ClientTestsBase.cs
@@ -9,6 +9,7 @@ using TwitchLib.Communication.Models;
 using TwitchLib.Communication.Tests.Helpers;
 using Xunit;
 
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
 namespace TwitchLib.Communication.Tests.Clients
 {
     /// <summary>

--- a/src/TwitchLib.Communication/Interfaces/IClient.cs
+++ b/src/TwitchLib.Communication/Interfaces/IClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using TwitchLib.Communication.Events;
 
 namespace TwitchLib.Communication.Interfaces
@@ -56,14 +57,14 @@ namespace TwitchLib.Communication.Interfaces
         /// <returns>
         ///     <see langword="true"/> if a connection could be established, <see langword="false"/> otherwise
         /// </returns>
-        bool Open();
+        Task<bool> OpenAsync();
 
         /// <summary>
         ///     if the underlying Client is connected,
         ///     <br></br>
-        ///     <see cref="Close()"/> is invoked
+        ///     <see cref="CloseAsync()"/> is invoked
         ///     <br></br>
-        ///     before it makes a call to <see cref="Open()"/> and <see cref="RaiseConnected()"/>
+        ///     before it makes a call to <see cref="OpenAsync()"/> and <see cref="RaiseConnected()"/>
         ///     <br></br>
         ///     <br></br>
         ///     this Method is also used by 'TwitchLib.Client.TwitchClient' 
@@ -81,25 +82,25 @@ namespace TwitchLib.Communication.Interfaces
         /// <returns>
         ///     <see langword="true"/>, if the client reconnected; <see langword="false"/> otherwise
         /// </returns>
-        bool Reconnect();
+        Task<bool> ReconnectAsync();
 
         /// <summary>
         ///     stops everything
         ///     and waits for the via <see cref="IClientOptions.DisconnectWait"/> given amount of milliseconds
         /// </summary>
-        void Close();
+        Task CloseAsync();
 
         /// <summary>
-        ///     sends the given irc-<paramref name="message"/>
+        ///     Sends the given irc-<paramref name="message"/>
         /// </summary>
         /// <param name="message">
         ///     irc-message to send
         /// </param>
         /// <returns>
-        ///     <see langword="true"/>, if the message should be sent
+        ///     <see langword="true"/>, if the message was sent
         ///     <br></br>
         ///     <see langword="false"/> otherwise
         /// </returns>
-        bool Send(string message);
+        Task<bool> SendAsync(string message);
     }
 }

--- a/src/TwitchLib.Communication/Services/NetworkServices.cs
+++ b/src/TwitchLib.Communication/Services/NetworkServices.cs
@@ -38,17 +38,19 @@ namespace TwitchLib.Communication.Services
                 // this task is probably still running
                 // may be in case of a network connection loss
                 // all other Tasks haven't been started or have been canceled!
-                // ConnectionWatchDog is the only one, that has a seperate CancellationTokenSource!
-                _monitorTask = _connectionWatchDog.StartMonitorTask();
+                // ConnectionWatchDog is the only one, that has a separate CancellationTokenSource!
+                
+                // Let those tasks run in the background, do not await them
+                _monitorTask = _connectionWatchDog.StartMonitorTaskAsync();
             }
 
-            _listenTask = Task.Run(_client.ListenTaskAction, Token);
+            _listenTask = Task.Run(_client.ListenTaskActionAsync, Token);
         }
 
-        internal void Stop()
+        internal async Task StopAsync()
         {
             _logger?.TraceMethodCall(GetType());
-            _connectionWatchDog.Stop();
+            await _connectionWatchDog.StopAsync();
         }
     }
 }


### PR DESCRIPTION
Removed all GetAwaiter().GetResult() and replaced it with proper async/await
Renamed all methods that handles tasks with Async postfix
Changed IClient interface to be async
Replaced lock with semaphore
Fixed tests to not wait after disposing