### PR TITLE
code improvement and bug fix in `WebSocketClient`

### DIFF
--- a/src/TwitchLib.Communication/Clients/ClientBase.cs
+++ b/src/TwitchLib.Communication/Clients/ClientBase.cs
@@ -135,11 +135,9 @@ namespace TwitchLib.Communication.Clients
                 return;
             }
 
-            var onFatalErrorEventArgs = new OnFatalErrorEventArgs("Fatal network error.");
-            if (ex != null)
-            {
-                onFatalErrorEventArgs = new OnFatalErrorEventArgs(ex);
-            }
+            var onFatalErrorEventArgs = ex != null
+                ? new OnFatalErrorEventArgs(ex)
+                : new OnFatalErrorEventArgs("Fatal network error.");
 
             OnFatality?.Invoke(this, onFatalErrorEventArgs);
         }

--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -114,14 +114,14 @@ namespace TwitchLib.Communication.Clients
                 // the following two answers:
                 // https://stackoverflow.com/a/11191070
                 // https://stackoverflow.com/a/22078975
-                
+
                 using (var delayTaskCancellationTokenSource = new CancellationTokenSource())
                 {
                     var connectTask = Client.ConnectAsync(Url, Port);
                     var delayTask = Task.Delay(
                         (int)TimeOutEstablishConnection.TotalMilliseconds,
                         delayTaskCancellationTokenSource.Token);
-                    
+
                     await Task.WhenAny(connectTask, delayTask);
                     delayTaskCancellationTokenSource.Cancel();
                 }
@@ -133,18 +133,15 @@ namespace TwitchLib.Communication.Clients
                 }
 
                 Logger?.TraceAction(GetType(), "Client established connection successfully");
+                Stream stream = Client.GetStream();
                 if (Options.UseSsl)
                 {
-                    var ssl = new SslStream(Client.GetStream(), false);
+                    var ssl = new SslStream(stream, false);
                     await ssl.AuthenticateAsClientAsync(Url);
-                    _reader = new StreamReader(ssl);
-                    _writer = new StreamWriter(ssl);
+                    stream = ssl;
                 }
-                else
-                {
-                    _reader = new StreamReader(Client.GetStream());
-                    _writer = new StreamWriter(Client.GetStream());
-                }
+                _reader = new StreamReader(stream);
+                _writer = new StreamWriter(stream);
             }
             catch (Exception ex) when (ex.GetType() == typeof(TaskCanceledException) ||
                                        ex.GetType() == typeof(OperationCanceledException))

--- a/src/TwitchLib.Communication/Extensions/LogExtensions.cs
+++ b/src/TwitchLib.Communication/Extensions/LogExtensions.cs
@@ -17,7 +17,7 @@ namespace TwitchLib.Communication.Extensions
             // because of the code-formatting, 2 line is subtracted from the callerLineNumber
             // cant be done inline!
             callerLineNumber -= 2;
-            logger?.LogTrace("{FullName}.{callerMemberName} at line {callerLineNumber} is called",
+            logger.LogTrace("{FullName}.{callerMemberName} at line {callerLineNumber} is called",
                              type.FullName, callerMemberName, callerLineNumber);
         }
         public static void LogExceptionAsError(this ILogger logger,
@@ -26,7 +26,7 @@ namespace TwitchLib.Communication.Extensions
                                                [CallerMemberName] string callerMemberName = "",
                                                [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger?.LogError(exception,
+            logger.LogError(exception,
                              "Exception in {FullName}.{callerMemberName} at line {callerLineNumber}:",
                              type.FullName, callerMemberName, callerLineNumber);
         }
@@ -36,7 +36,7 @@ namespace TwitchLib.Communication.Extensions
                                                      [CallerMemberName] string callerMemberName = "",
                                                      [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger?.LogInformation(exception,
+            logger.LogInformation(exception,
                                    "Exception in {FullName}.{callerMemberName} at line {callerLineNumber}:",
                                    type.FullName, callerMemberName, callerLineNumber);
         }
@@ -46,7 +46,7 @@ namespace TwitchLib.Communication.Extensions
                                        [CallerMemberName] string callerMemberName = "",
                                        [CallerLineNumber] int callerLineNumber = 0)
         {
-            logger?.LogTrace("{FullName}.{callerMemberName} at line {callerLineNumber}: {action}",
+            logger.LogTrace("{FullName}.{callerMemberName} at line {callerLineNumber}: {action}",
                              type.FullName, callerMemberName, callerLineNumber, action);
         }
     }


### PR DESCRIPTION
Code improvements:
- removed redundant null checks
- less memory allocation
- simplified/more readable TcpClient initialize

Bug fix:
- some long messages (longer than 1024 bytes) were split by splitting 1 `char` between 2 parts of the message, so the message could not be decoded correctly

not sure if this is clear so here is a real example:
client initialization
```cs
var c1 = new TwitchClient();
c1.Initialize(
    new ConnectionCredentials("username", "oauth", capabilities: new Capabilities(false, false, false)),
    "channel"
    );
c1.Connect();
c1.OnMessageReceived += (s, e) => Console.WriteLine(e.ChatMessage.Message);
await Task.Delay(-1);
```
message that was sent on twitch.tv:
```
žžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽ
```
received message (look at the 5-6th character from the end):
```
žžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžžŽŽŽŽŽžžžžž??ŽŽŽŽ
```