### PR TITLE
improve logging performance

### DIFF
--- a/src/TwitchLib.Communication/Clients/ClientBase.cs
+++ b/src/TwitchLib.Communication/Clients/ClientBase.cs
@@ -37,7 +37,7 @@ namespace TwitchLib.Communication.Clients
         
         internal static TimeSpan TimeOutEstablishConnection => TimeSpan.FromSeconds(15);
 
-        protected ILogger? Logger { get; }
+        protected readonly ILogger? Logger;
         
         protected abstract string Url { get; }
         

--- a/src/TwitchLib.Communication/Clients/ClientBase.cs
+++ b/src/TwitchLib.Communication/Clients/ClientBase.cs
@@ -37,7 +37,7 @@ namespace TwitchLib.Communication.Clients
         
         internal static TimeSpan TimeOutEstablishConnection => TimeSpan.FromSeconds(15);
 
-        protected readonly ILogger? Logger;
+        protected readonly ILogger<ClientBase<T>>? Logger;
         
         protected abstract string Url { get; }
         
@@ -60,7 +60,7 @@ namespace TwitchLib.Communication.Clients
 
         internal ClientBase(
             IClientOptions? options,
-            ILogger? logger)
+            ILogger<ClientBase<T>>? logger)
         {
             Logger = logger;
             _cancellationTokenSource = new CancellationTokenSource();

--- a/src/TwitchLib.Communication/Clients/TcpClient.cs
+++ b/src/TwitchLib.Communication/Clients/TcpClient.cs
@@ -23,7 +23,7 @@ namespace TwitchLib.Communication.Clients
 
         public TcpClient(
             IClientOptions? options = null,
-            ILogger? logger = null)
+            ILogger<TcpClient>? logger = null)
             : base(options, logger)
         {
         }

--- a/src/TwitchLib.Communication/Clients/WebsocketClient.cs
+++ b/src/TwitchLib.Communication/Clients/WebsocketClient.cs
@@ -20,7 +20,7 @@ namespace TwitchLib.Communication.Clients
 
         public WebSocketClient(
             IClientOptions? options = null,
-            ILogger? logger = null)
+            ILogger<WebSocketClient>? logger = null)
             : base(options, logger)
         {
             switch (Options.ClientType)

--- a/src/TwitchLib.Communication/Extensions/LogExtensions.cs
+++ b/src/TwitchLib.Communication/Extensions/LogExtensions.cs
@@ -1,53 +1,33 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿#pragma warning disable SYSLIB1006 // Multiple logging methods cannot use the same event id within a class
 using Microsoft.Extensions.Logging;
+using System;
+using System.Runtime.CompilerServices;
 
 namespace TwitchLib.Communication.Extensions
 {
     /// <summary>
     ///     expensive Extensions of the <see cref="ILogger"/>
     /// </summary>
-    internal static class LogExtensions
+    internal static partial class LogExtensions
     {
-        public static void TraceMethodCall(this ILogger logger,
-                                           Type type,
-                                           [CallerMemberName] string callerMemberName = "",
-                                           [CallerLineNumber] int callerLineNumber = 0)
+        public static void TraceMethodCall(this ILogger logger, Type type, [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = 0)
         {
             // because of the code-formatting, 2 line is subtracted from the callerLineNumber
             // cant be done inline!
             callerLineNumber -= 2;
-            logger.LogTrace("{FullName}.{callerMemberName} at line {callerLineNumber} is called",
-                             type.FullName, callerMemberName, callerLineNumber);
+            TraceMethodCallCore(logger, type, callerMemberName, callerLineNumber);
         }
-        public static void LogExceptionAsError(this ILogger logger,
-                                               Type type,
-                                               Exception exception,
-                                               [CallerMemberName] string callerMemberName = "",
-                                               [CallerLineNumber] int callerLineNumber = 0)
-        {
-            logger.LogError(exception,
-                             "Exception in {FullName}.{callerMemberName} at line {callerLineNumber}:",
-                             type.FullName, callerMemberName, callerLineNumber);
-        }
-        public static void LogExceptionAsInformation(this ILogger logger,
-                                                     Type type,
-                                                     Exception exception,
-                                                     [CallerMemberName] string callerMemberName = "",
-                                                     [CallerLineNumber] int callerLineNumber = 0)
-        {
-            logger.LogInformation(exception,
-                                   "Exception in {FullName}.{callerMemberName} at line {callerLineNumber}:",
-                                   type.FullName, callerMemberName, callerLineNumber);
-        }
-        public static void TraceAction(this ILogger logger,
-                                       Type type,
-                                       string action,
-                                       [CallerMemberName] string callerMemberName = "",
-                                       [CallerLineNumber] int callerLineNumber = 0)
-        {
-            logger.LogTrace("{FullName}.{callerMemberName} at line {callerLineNumber}: {action}",
-                             type.FullName, callerMemberName, callerLineNumber, action);
-        }
+
+        [LoggerMessage(0, LogLevel.Trace, "{type}.{callerMemberName} at line {callerLineNumber} is called")]
+        static partial void TraceMethodCallCore(this ILogger logger, Type type, string callerMemberName, int callerLineNumber);
+
+        [LoggerMessage(0, LogLevel.Error, "Exception in {type}.{callerMemberName} at line {callerLineNumber}")]
+        public static partial void LogExceptionAsError(this ILogger logger, Type type, Exception exception, [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = 0);
+
+        [LoggerMessage(0, LogLevel.Information, "Exception in {type}.{callerMemberName} at line {callerLineNumber}")]
+        public static partial void LogExceptionAsInformation(this ILogger logger, Type type, Exception exception, [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = 0);
+
+        [LoggerMessage(0, LogLevel.Trace, "{type}.{callerMemberName} at line {callerLineNumber}: {action}")]
+        public static partial void TraceAction(this ILogger logger, Type type, string action, [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = 0);
     }
 }


### PR DESCRIPTION
Improved performance for logging when the logger is not set to `null`.

Questions:

- Should we combine `LogExceptionAsError` and `LogExceptionAsInformation` into one method with the `LogLevel` parameter?
- ~~Should we change the logger type in the `TcpClient`/`WebSocketClient`(/`ClientBase<T>`?) constructor to a generic version?~~ 
I changed it to the generic version because all other libs use generic version.