### PR TITLE
ConnectClientAsync - Fix "Cannot access a disposed object."

### DIFF
--- a/src/TwitchLib.Communication/Clients/ClientBase.cs
+++ b/src/TwitchLib.Communication/Clients/ClientBase.cs
@@ -237,9 +237,6 @@ public abstract class ClientBase<T> : IClient
                 return true;
             }
 
-            // Always create new client when opening new connection
-            Client = CreateClient();
-
             var first = true;
             Options.ReconnectionPolicy.Reset(isReconnect);
 
@@ -247,6 +244,10 @@ public abstract class ClientBase<T> : IClient
                    !Options.ReconnectionPolicy.AreAttemptsComplete())
             {
                 Logger?.TraceAction(GetType(), "try to connect");
+
+                // Always create new client when opening new connection
+                Client = CreateClient();
+
                 if (!first)
                 {
                     await Task.Delay(Options.ReconnectionPolicy.GetReconnectInterval(), CancellationToken.None);


### PR DESCRIPTION
Move "Always create new client when opening new connection" into the while loop to really make sure it always is a new Client when opening a new connection.

Roughly tested to be working with both TcpClient and WebSocketClient.

Fixes issue #30